### PR TITLE
feat: add formatting for remaining minutes in lesson notifications

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -9,7 +9,7 @@ import { getUkrainianDayAbbr, getTomorrow } from './utils/date.utils';
 import { isAdmin } from './utils/admin.guard';
 import { createRateLimiterMiddleware } from './services/rateLimiter.service';
 import { createConcurrencyMiddleware } from './services/concurrency.service';
-import { getCurrentLesson, formatNowMessage, getNextLesson, formatNextMessage } from './utils/currentLesson';
+import { getCurrentLesson, formatNowMessage, getNextLesson, formatNextMessage, formatMinutesLeft } from './utils/currentLesson';
 import { toggleReminder } from './services/reminder.service';
 
 import { handleTeacherCommand } from './services/teacher.service';
@@ -404,7 +404,7 @@ export function createBot(deps?: { notificationRepo?: NotificationRepo }): Teleg
                 return;
             }
 
-            await ctx.reply(`До кінця пари: ${active.minutesLeft} хв`);
+            await ctx.reply(`До кінця пари: ${formatMinutesLeft(active.minutesLeft)}`);
         } catch (err) {
             logger.error('Error in /left:', err);
             await ctx.reply('Тимчасово не вдалося отримати розклад.');

--- a/src/utils/currentLesson.ts
+++ b/src/utils/currentLesson.ts
@@ -89,6 +89,16 @@ export function calculateMinutesLeft(endHHMM: string, nowMinutes: number): numbe
 }
 
 /**
+ * Formats minutes remaining as "X хв" if < 60, or "X год Y хв" if >= 60.
+ */
+export function formatMinutesLeft(minutes: number): string {
+    if (minutes < 60) return `${minutes} хв`;
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return m === 0 ? `${h} год` : `${h} год ${m} хв`;
+}
+
+/**
  * Formats the HTML reply for /now given an active lesson and an optional
  * pre-resolved DB link. Keeping the link resolution outside this function
  * keeps it pure and easy to test.
@@ -115,7 +125,7 @@ export function formatNowMessage(active: ActiveLesson, link: string | null): str
         `Станом на зараз:\n` +
         `${timeRange}\n` +
         `${typeEmoji} ${nameDisplay}\n\n` +
-        `До кінця пари: ${minutesLeft} хв`
+        `До кінця пари: ${formatMinutesLeft(minutesLeft)}`
     );
 }
 


### PR DESCRIPTION
**Changes**
- Added [formatMinutesLeft()](https://github.com/AnnKuts/shedule-kpi-im41/blob/d3f0497e4c234f401ade932193fc86df439bec0e/src/utils/currentLesson.ts#L94) helper that formats minutes as "X хв" when < 60 or "X год Y хв" when >= 60
- Updated /now and /left commands to use the new format

**Related Issues**
- Closes #2