### PR TITLE
fix: handle @botname suffix in command parsers, normalize lesson types

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -231,7 +231,7 @@ export function createBot(deps?: { notificationRepo?: NotificationRepo }): Teleg
         }
         try {
             const text = ctx.message && 'text' in ctx.message ? ctx.message.text : '';
-            const withoutCmd = text.replace(/^\/setlink\s*/i, '').trim();
+            const withoutCmd = text.replace(/^\/setlink(?:@\w+)?\s*/i, '').trim();
 
             let lessonName: string;
             let rest: string;
@@ -302,7 +302,7 @@ export function createBot(deps?: { notificationRepo?: NotificationRepo }): Teleg
         }
         try {
             const text = ctx.message && 'text' in ctx.message ? ctx.message.text : '';
-            const withoutCmd = text.replace(/^\/deletelink\s*/i, '').trim();
+            const withoutCmd = text.replace(/^\/deletelink(?:@\w+)?\s*/i, '').trim();
 
             let lessonName: string;
             let lessonType: string;

--- a/src/services/teacher.service.ts
+++ b/src/services/teacher.service.ts
@@ -19,7 +19,7 @@ export interface TeacherResult {
 
 // ─── Regex command parser ─────────────────────────────────────────────────────
 
-const TEACHER_REGEX = /^\/teacher\s+"([^"]+)"\s*(.*)$/i;
+const TEACHER_REGEX = /^\/teacher(?:@\w+)?\s+"([^"]+)"\s*(.*)$/i;
 
 export type ParseTeacherResult =
     | { ok: true; subjectName: string; type: string | null }
@@ -81,7 +81,7 @@ export function findTeachers(
 
     const matched = allLessons.filter((l) => {
         if (l.name.toLowerCase() !== nameLower) return false;
-        if (typeLower && !l.type.toLowerCase().startsWith(typeLower)) return false;
+        if (typeLower && !normalizeType(l.type).toLowerCase().startsWith(typeLower)) return false;
         return true;
     });
 

--- a/tests/unit/teacher.service.test.ts
+++ b/tests/unit/teacher.service.test.ts
@@ -77,6 +77,24 @@ describe('parseTeacherCommand — parsing', () => {
         if (r.ok) expect(r.subjectName).toBe('Алгебра');
     });
 
+    it('parses command with @botname suffix', () => {
+        const r = parseTeacherCommand('/teacher@test_im_41_shedule_kpi_bot "Системне програмування"');
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+            expect(r.subjectName).toBe('Системне програмування');
+            expect(r.type).toBeNull();
+        }
+    });
+
+    it('parses command with @botname suffix and type', () => {
+        const r = parseTeacherCommand('/teacher@mybot "Системне програмування" Лекція');
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+            expect(r.subjectName).toBe('Системне програмування');
+            expect(r.type).toBe('Лекція');
+        }
+    });
+
     it('returns error when no quotes provided', () => {
         const r = parseTeacherCommand('/teacher Системне програмування');
         expect(r.ok).toBe(false);
@@ -138,6 +156,25 @@ describe('findTeachers — search logic', () => {
         // "лек" matches "Лекція" via prefix
         const teachers = findTeachers(LESSONS, 'Системне програмування', 'лек');
         expect(teachers).toHaveLength(1);
+    });
+
+    it('matches abbreviated API types (e.g. "Лек." matches user input "Лекція")', () => {
+        const lessons = [
+            makeLesson({ name: 'Предмет', type: 'Лек.', lecturer: { id: '1', name: 'Іваненко І.О.' } }),
+            makeLesson({ name: 'Предмет', type: 'Лаб.', lecturer: { id: '2', name: 'Петренко П.П.' } }),
+        ];
+        const teachers = findTeachers(lessons, 'Предмет', 'Лекція');
+        expect(teachers).toHaveLength(1);
+        expect(teachers[0].name).toBe('Іваненко І.О.');
+    });
+
+    it('matches abbreviated API type "Лаб." against user input "Лаба"', () => {
+        const lessons = [
+            makeLesson({ name: 'Предмет', type: 'Лаб.', lecturer: { id: '3', name: 'Коваленко К.К.' } }),
+        ];
+        const teachers = findTeachers(lessons, 'Предмет', 'Лаба');
+        expect(teachers).toHaveLength(1);
+        expect(teachers[0].name).toBe('Коваленко К.К.');
     });
 
     it('returns empty array when subject not found', () => {


### PR DESCRIPTION
**Changes**
- Updated [TEACHER_REGEX](https://github.com/AnnKuts/shedule-kpi-im41/blob/fix-issue-6/src/services/teacher.service.ts#L22) to include optional `(?:@\w+)?` group so commands like `/teacher@botname "Subject"` parse correctly in group chats
- Updated [findTeachers()](https://github.com/AnnKuts/shedule-kpi-im41/blob/fix-issue-6/src/services/teacher.service.ts#L84) filter to wrap `l.type` in `normalizeType()` before comparison, fixing type filtering when the KPI API returns abbreviated types like `"Лек."` instead of `"Лекція"`
- Updated `/setlink` and `/deletelink` command prefix-strip regexes in [bot.ts](https://github.com/AnnKuts/shedule-kpi-im41/blob/fix-issue-6/src/bot.ts) to ignore optional `@botname` suffix
- Added 4 unit tests to [teacher.service.test.ts](https://github.com/AnnKuts/shedule-kpi-im41/blob/fix-issue-6/tests/unit/teacher.service.test.ts) covering `@botname` parsing and abbreviated API type matching

**Related Issues**
- Closes #6