### PR TITLE
feat: implement CSV export and import commands for lesson links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.7",
         "better-sqlite3": "^9.4.3",
+        "delayed-stream": "^1.0.0",
         "dotenv": "^16.4.1",
         "express": "^4.18.2",
         "node-cache": "^5.1.2",
@@ -24,6 +25,7 @@
         "@types/node-cron": "^3.0.11",
         "@types/supertest": "^6.0.3",
         "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/mocker": "^4.0.18",
         "axios-mock-adapter": "^2.1.0",
         "supertest": "^7.2.2",
         "ts-node-dev": "^2.0.0",
@@ -1293,7 +1295,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
       "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.0.18",
         "estree-walker": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "axios": "^1.6.7",
     "better-sqlite3": "^9.4.3",
+    "delayed-stream": "^1.0.0",
     "dotenv": "^16.4.1",
     "express": "^4.18.2",
     "node-cache": "^5.1.2",
@@ -28,6 +29,7 @@
     "@types/node-cron": "^3.0.11",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/mocker": "^4.0.18",
     "axios-mock-adapter": "^2.1.0",
     "supertest": "^7.2.2",
     "ts-node-dev": "^2.0.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,9 +1,10 @@
+import axios from 'axios';
 import { Telegraf, Context, Markup } from 'telegraf';
 import { config } from './config';
 import { logger } from './utils/logger';
 import { scheduleService, fetchActiveWeek } from './services/schedule.service';
 import { dbService } from './database/db';
-import { formatDay, formatWeek, LEGEND_HEADER } from './utils/format.utils';
+import { formatDay, formatWeek, LEGEND_HEADER, normalizeLessonType } from './utils/format.utils';
 import { splitWeekMessageByDay } from './utils/messageSplitter';
 import { getUkrainianDayAbbr, getTomorrow } from './utils/date.utils';
 import { isAdmin } from './utils/admin.guard';
@@ -13,6 +14,7 @@ import { getCurrentLesson, formatNowMessage, getNextLesson, formatNextMessage } 
 import { toggleReminder } from './services/reminder.service';
 
 import { handleTeacherCommand } from './services/teacher.service';
+import { generateCsv, parseCsv } from './services/linkCsv.service';
 import type { NotificationRepo } from './database/notificationRepo';
 
 // ─── Telegram message size limit ─────────────────────────────────────────────
@@ -119,6 +121,7 @@ export function createBot(deps?: { notificationRepo?: NotificationRepo }): Teleg
             '/tomorrow — розклад на завтра\n' +
             '/week — розклад на тиждень\n' +
             '/fortnight — переглянути та перемикати тижні\n' +
+            '/exportlinks — завантажити CSV з посиланнями\n' +
             '/setlink &lt;назва&gt; &lt;тип&gt; &lt;url&gt; — зберегти посилання\n' +
             '/deletelink &lt;назва&gt; &lt;тип&gt; — видалити посилання\n\n' +
             'Типи: Лекція | Практика | Лаба';
@@ -335,6 +338,88 @@ export function createBot(deps?: { notificationRepo?: NotificationRepo }): Teleg
         }
     });
 
+    // ─── /exportlinks ────────────────────────────────────────────────────────
+    // Available to all users. Sends a pipe-separated CSV of all known lesson
+    // pairs with their current links pre-filled (empty = no link saved).
+    bot.command('exportlinks', async (ctx: Context) => {
+        try {
+            const lessons = await scheduleService.getAllLessons();
+            const links = dbService.getAllLinks();
+            const csv = generateCsv(lessons, links);
+            // BOM prefix so the file opens correctly in Excel / LibreOffice
+            const buffer = Buffer.from('\uFEFF' + csv, 'utf-8');
+            await ctx.replyWithDocument({ source: buffer, filename: 'links.csv' });
+        } catch (err) {
+            logger.error('Error in /exportlinks:', err);
+            await ctx.reply('❌ Не вдалося згенерувати файл. Спробуйте пізніше.');
+        }
+    });
+
+    // ─── /importlinks (via document caption) ─────────────────────────────────
+    // Admin-only. User attaches the filled CSV file with caption "/importlinks"
+    // (or "/importlinks@botname"). Bot downloads the file, parses each row, and
+    // either sets or deletes the link depending on whether the link column is
+    // empty.
+    bot.on('document', async (ctx) => {
+        const caption = ('caption' in ctx.message ? ctx.message.caption : undefined) ?? '';
+        if (!/^\/importlinks(@\w+)?\s*$/i.test(caption.trim())) return;
+
+        if (!isAdmin(ctx)) {
+            logger.warn(
+                `[SECURITY] Unauthorized admin attempt: /importlinks by userId=${ctx.from?.id ?? 'unknown'} username=@${ctx.from?.username ?? 'unknown'}`,
+            );
+            await ctx.reply('У вас немає прав для цієї команди.');
+            return;
+        }
+
+        try {
+            const doc = ctx.message.document;
+            const fileLink = await ctx.telegram.getFileLink(doc.file_id);
+            const { data: csvText } = await axios.get<string>(fileLink.href, {
+                responseType: 'text',
+                timeout: 10_000,
+            });
+
+            const parsed = parseCsv(csvText);
+            if (!parsed.ok) {
+                await ctx.reply(`⚠️ ${parsed.error}`);
+                return;
+            }
+
+            let set = 0;
+            let deleted = 0;
+            let skipped = 0;
+
+            for (const row of parsed.rows) {
+                if (row.link) {
+                    const urlError = validateUrl(row.link);
+                    if (urlError) {
+                        logger.warn(
+                            `[SECURITY] Invalid URL in /importlinks by userId=${ctx.from?.id ?? 'unknown'}: ${row.link}`,
+                        );
+                        skipped++;
+                        continue;
+                    }
+                    dbService.setLink(row.lessonName, row.lessonType, row.link);
+                    set++;
+                } else {
+                    const wasDeleted = dbService.deleteLink(row.lessonName, row.lessonType);
+                    if (wasDeleted) deleted++;
+                }
+            }
+
+            await ctx.reply(
+                `✅ Імпорт завершено:\n` +
+                `• збережено: ${set}\n` +
+                `• видалено: ${deleted}\n` +
+                `• пропущено (некоректний URL): ${skipped}`,
+            );
+        } catch (err) {
+            logger.error('Error in /importlinks:', err);
+            await ctx.reply('❌ Не вдалося обробити файл. Перевірте формат CSV.');
+        }
+    });
+
     // ─── /next ────────────────────────────────────────────────────────
     bot.command('next', async (ctx: Context) => {
         try {
@@ -349,12 +434,7 @@ export function createBot(deps?: { notificationRepo?: NotificationRepo }): Teleg
             }
 
             const { lesson } = next;
-            const dbLabel =
-                lesson.type.startsWith('Лек') ? 'Лекція'
-                    : lesson.type.startsWith('Прак') ? 'Практика'
-                        : lesson.type.startsWith('Лаб') ? 'Лаба'
-                            : lesson.type;
-            const link = dbService.getLink(lesson.name, dbLabel);
+            const link = dbService.getLink(lesson.name, normalizeLessonType(lesson.type));
 
             await ctx.replyWithHTML(formatNextMessage(next, link));
         } catch (err) {
@@ -377,12 +457,7 @@ export function createBot(deps?: { notificationRepo?: NotificationRepo }): Teleg
             }
 
             const { lesson } = active;
-            const dbLabel =
-                lesson.type.startsWith('Лек') ? 'Лекція'
-                    : lesson.type.startsWith('Прак') ? 'Практика'
-                        : lesson.type.startsWith('Лаб') ? 'Лаба'
-                            : lesson.type;
-            const link = dbService.getLink(lesson.name, dbLabel);
+            const link = dbService.getLink(lesson.name, normalizeLessonType(lesson.type));
 
             await ctx.replyWithHTML(formatNowMessage(active, link));
         } catch (err) {

--- a/src/services/linkCsv.service.ts
+++ b/src/services/linkCsv.service.ts
@@ -1,0 +1,119 @@
+import type { Lesson, LessonLink } from '../types/kpi.types';
+import { normalizeLessonType } from '../utils/format.utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CsvRow {
+    lessonName: string;
+    lessonType: string;
+    /** Empty string means "delete this link from DB" */
+    link: string;
+}
+
+export type ParseCsvResult =
+    | { ok: true; rows: CsvRow[] }
+    | { ok: false; error: string };
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CSV_SEPARATOR = '|';
+const CSV_HEADER = `lesson_name${CSV_SEPARATOR}lesson_type${CSV_SEPARATOR}link`;
+
+const TYPE_ORDER: Record<string, number> = {
+    'Лекція': 0,
+    'Практика': 1,
+    'Лаба': 2,
+};
+
+// ─── Generate ─────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a pipe-separated CSV string from all unique (name, type) lesson pairs
+ * found in the API schedule, pre-filling any existing links from the DB.
+ *
+ * Rows are sorted alphabetically by lesson_name, then by canonical type order
+ * (Лекція → Практика → Лаба → other).
+ */
+export function generateCsv(lessons: Lesson[], existingLinks: LessonLink[]): string {
+    // Collect unique (name, normalizedType) pairs
+    const seen = new Set<string>();
+    const pairs: Array<{ name: string; type: string }> = [];
+
+    for (const lesson of lessons) {
+        const type = normalizeLessonType(lesson.type);
+        const key = `${lesson.name}${CSV_SEPARATOR}${type}`;
+        if (!seen.has(key)) {
+            seen.add(key);
+            pairs.push({ name: lesson.name, type });
+        }
+    }
+
+    // Sort: by name alphabetically, then by canonical type order
+    pairs.sort((a, b) => {
+        const nameCmp = a.name.localeCompare(b.name, 'uk');
+        if (nameCmp !== 0) return nameCmp;
+        const aOrder = TYPE_ORDER[a.type] ?? 99;
+        const bOrder = TYPE_ORDER[b.type] ?? 99;
+        return aOrder - bOrder;
+    });
+
+    // Build lookup map for existing links
+    const linkMap = new Map<string, string>();
+    for (const row of existingLinks) {
+        linkMap.set(`${row.lesson_name}${CSV_SEPARATOR}${row.lesson_type}`, row.link);
+    }
+
+    const lines: string[] = [CSV_HEADER];
+    for (const { name, type } of pairs) {
+        const link = linkMap.get(`${name}${CSV_SEPARATOR}${type}`) ?? '';
+        lines.push(`${name}${CSV_SEPARATOR}${type}${CSV_SEPARATOR}${link}`);
+    }
+
+    return lines.join('\n');
+}
+
+// ─── Parse ────────────────────────────────────────────────────────────────────
+
+/**
+ * Parses a pipe-separated CSV string back into structured rows.
+ *
+ * - Strips UTF-8 BOM if present
+ * - Skips the header row (lesson_name|lesson_type|link)
+ * - Skips blank lines
+ * - Returns { ok: false } if no valid data rows are found
+ * - Rows with fewer than 2 fields are skipped (counted separately by caller)
+ */
+export function parseCsv(text: string): ParseCsvResult {
+    // Strip UTF-8 BOM
+    const clean = text.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+    const lines = clean.split('\n');
+    const rows: CsvRow[] = [];
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+
+        // Skip header row (case-insensitive to be safe)
+        if (line.toLowerCase().startsWith('lesson_name')) continue;
+
+        const parts = line.split(CSV_SEPARATOR);
+
+        // Need at least lesson_name and lesson_type; link may be absent (= empty)
+        if (parts.length < 2) continue;
+
+        const lessonName = (parts[0] ?? '').trim();
+        const lessonType = (parts[1] ?? '').trim();
+        const link = (parts[2] ?? '').trim();
+
+        if (!lessonName || !lessonType) continue;
+
+        rows.push({ lessonName, lessonType, link });
+    }
+
+    if (rows.length === 0) {
+        return { ok: false, error: 'CSV файл не містить жодного рядка з даними.' };
+    }
+
+    return { ok: true, rows };
+}

--- a/src/utils/format.utils.ts
+++ b/src/utils/format.utils.ts
@@ -23,6 +23,14 @@ function getTypeMeta(type: string): TypeMeta {
     return { icon: '⚪', dbLabel: type };
 }
 
+/**
+ * Converts a raw API lesson type (e.g. "Лек.", "Прак.") to the canonical
+ * DB label ("Лекція", "Практика", "Лаба"). Unknown types are returned as-is.
+ */
+export function normalizeLessonType(rawType: string): string {
+    return getTypeMeta(rawType).dbLabel;
+}
+
 // ─── Legend header ────────────────────────────────────────────────────────────
 
 export const LEGEND_HEADER = 'Група: ІМ-41\n🔵 Лекція 🟠 Практика 🟢 Лаба';

--- a/tests/unit/linkCsv.service.test.ts
+++ b/tests/unit/linkCsv.service.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { generateCsv, parseCsv } from '../../src/services/linkCsv.service';
+import type { Lesson, LessonLink } from '../../src/types/kpi.types';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeLesson(name: string, type: string): Lesson {
+    return {
+        name,
+        type,
+        lecturer: { id: '1', name: 'Test Lecturer' },
+        time: '08:30:00',
+        place: '101',
+        location: null,
+        tag: '',
+        dates: ['2024-01-01'],
+    };
+}
+
+function makeLink(lesson_name: string, lesson_type: string, link: string): LessonLink {
+    return { lesson_name, lesson_type, link };
+}
+
+// ─── generateCsv ──────────────────────────────────────────────────────────────
+
+describe('generateCsv', () => {
+    it('outputs header as first line', () => {
+        const csv = generateCsv([], []);
+        expect(csv.split('\n')[0]).toBe('lesson_name|lesson_type|link');
+    });
+
+    it('produces one row per unique (name, normalizedType) pair', () => {
+        const lessons = [
+            makeLesson('Математика', 'Лекція'),
+            makeLesson('Математика', 'Лекція'), // duplicate
+            makeLesson('Математика', 'Лаба'),
+        ];
+        const csv = generateCsv(lessons, []);
+        const rows = csv.split('\n').slice(1); // skip header
+        expect(rows).toHaveLength(2);
+    });
+
+    it('normalizes raw API types (e.g. "Лек." → "Лекція")', () => {
+        const lessons = [makeLesson('ОС', 'Лек.')];
+        const csv = generateCsv(lessons, []);
+        expect(csv).toContain('ОС|Лекція|');
+    });
+
+    it('pre-fills existing link for matching row', () => {
+        const lessons = [makeLesson('Фізика', 'Лекція')];
+        const links = [makeLink('Фізика', 'Лекція', 'https://zoom.us/j/123')];
+        const csv = generateCsv(lessons, links);
+        expect(csv).toContain('Фізика|Лекція|https://zoom.us/j/123');
+    });
+
+    it('leaves link empty when no DB entry exists', () => {
+        const lessons = [makeLesson('Хімія', 'Лаба')];
+        const csv = generateCsv(lessons, []);
+        expect(csv).toContain('Хімія|Лаба|');
+        // Ensure no extra content after the last pipe
+        const dataLine = csv.split('\n')[1];
+        expect(dataLine).toBe('Хімія|Лаба|');
+    });
+
+    it('sorts rows by lesson_name alphabetically, then by type order (Лекція < Практика < Лаба)', () => {
+        const lessons = [
+            makeLesson('Математика', 'Лаба'),
+            makeLesson('Математика', 'Лекція'),
+            makeLesson('Алгебра', 'Практика'),
+        ];
+        const csv = generateCsv(lessons, []);
+        const rows = csv.split('\n').slice(1);
+        expect(rows[0]).toMatch(/^Алгебра/);
+        expect(rows[1]).toMatch(/^Математика\|Лекція/);
+        expect(rows[2]).toMatch(/^Математика\|Лаба/);
+    });
+
+    it('returns only header when lessons array is empty', () => {
+        const csv = generateCsv([], []);
+        expect(csv.trim()).toBe('lesson_name|lesson_type|link');
+    });
+});
+
+// ─── parseCsv ─────────────────────────────────────────────────────────────────
+
+describe('parseCsv', () => {
+    it('parses a valid CSV with links', () => {
+        const csv = [
+            'lesson_name|lesson_type|link',
+            'Математика|Лекція|https://zoom.us/j/123',
+            'Фізика|Лаба|https://meet.google.com/abc',
+        ].join('\n');
+
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows).toHaveLength(2);
+        expect(result.rows[0]).toEqual({
+            lessonName: 'Математика',
+            lessonType: 'Лекція',
+            link: 'https://zoom.us/j/123',
+        });
+    });
+
+    it('parses rows with empty link field', () => {
+        const csv = 'lesson_name|lesson_type|link\nМатематика|Лекція|';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows[0]?.link).toBe('');
+    });
+
+    it('parses rows where link column is missing entirely', () => {
+        const csv = 'lesson_name|lesson_type|link\nМатематика|Лекція';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows[0]?.link).toBe('');
+    });
+
+    it('strips UTF-8 BOM', () => {
+        const csv = '\uFEFFlesson_name|lesson_type|link\nОС|Практика|https://example.com';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows[0]?.lessonName).toBe('ОС');
+    });
+
+    it('handles Windows CRLF line endings', () => {
+        const csv = 'lesson_name|lesson_type|link\r\nМатематика|Лекція|https://zoom.us/j/1\r\n';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows).toHaveLength(1);
+    });
+
+    it('skips the header row (case-insensitive)', () => {
+        const csv = 'LESSON_NAME|LESSON_TYPE|LINK\nМатематика|Лекція|https://example.com';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows).toHaveLength(1);
+    });
+
+    it('skips blank lines', () => {
+        const csv = 'lesson_name|lesson_type|link\n\nМатематика|Лекція|\n\n';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows).toHaveLength(1);
+    });
+
+    it('skips rows with only one field (malformed)', () => {
+        const csv = 'lesson_name|lesson_type|link\nМатематика\nФізика|Лаба|';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        // "Математика" alone has only 1 field → skipped; "Фізика|Лаба|" is valid
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0]?.lessonName).toBe('Фізика');
+    });
+
+    it('returns ok:false when no valid data rows exist', () => {
+        const csv = 'lesson_name|lesson_type|link\n\n';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(false);
+    });
+
+    it('returns ok:false for completely empty input', () => {
+        const result = parseCsv('');
+        expect(result.ok).toBe(false);
+    });
+
+    it('trims whitespace from field values', () => {
+        const csv = 'lesson_name|lesson_type|link\n  Математика  |  Лекція  |  https://example.com  ';
+        const result = parseCsv(csv);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.rows[0]).toEqual({
+            lessonName: 'Математика',
+            lessonType: 'Лекція',
+            link: 'https://example.com',
+        });
+    });
+});


### PR DESCRIPTION
**Changes**
- Added [normalizeLessonType()](https://github.com/AnnKuts/shedule-kpi-im41/blob/3e408c36c114b980986284bb09e34fa017830dd0/src/utils/format.utils.ts#L30) to [format.utils.ts](https://github.com/AnnKuts/shedule-kpi-im41/blob/feature/bulk-link-management/src/utils/format.utils.ts) — extracts existing private `getTypeMeta` logic into a public utility, removing duplicate type-normalization code from `/now` and `/next` handlers
- Added new [linkCsv.service.ts](https://github.com/AnnKuts/shedule-kpi-im41/blob/feature/bulk-link-management/src/services/linkCsv.service.ts) with [generateCsv()](https://github.com/AnnKuts/shedule-kpi-im41/blob/3e408c36c114b980986284bb09e34fa017830dd0/src/services/linkCsv.service.ts#L37) and [parseCsv()](https://github.com/AnnKuts/shedule-kpi-im41/blob/3e408c36c114b980986284bb09e34fa017830dd0/src/services/linkCsv.service.ts#L86) — pure functions for pipe-separated CSV generation and parsing, handling BOM, CRLF, deduplication, and sorting
- Added `/exportlinks` command to [bot.ts](https://github.com/AnnKuts/shedule-kpi-im41/blob/feature/bulk-link-management/src/bot.ts) — available to all users, sends a pre-filled CSV file with all lesson pairs and their current links
- Added `/importlinks` document handler to [bot.ts](https://github.com/AnnKuts/shedule-kpi-im41/blob/feature/bulk-link-management/src/bot.ts) — admin-only, accepts a CSV file with caption `/importlinks` (supports `@botname` suffix), sets or deletes links per row, replies with a set/deleted/skipped summary
- Added 17 unit tests to [linkCsv.service.test.ts](https://github.com/AnnKuts/shedule-kpi-im41/blob/feature/bulk-link-management/tests/unit/linkCsv.service.test.ts) covering `generateCsv` deduplication, sorting, link pre-fill, and `parseCsv` BOM, CRLF, malformed rows, empty input